### PR TITLE
Feat: 회원가입 ui 구현

### DIFF
--- a/src/components/Auth/AgeGroupSelect.tsx
+++ b/src/components/Auth/AgeGroupSelect.tsx
@@ -1,0 +1,56 @@
+// src/components/Auth/AgeGroupSelect.tsx
+
+interface AgeGroupSelectProps {
+  value: '' | 'over14' | 'under14';
+  onChange: (value: 'over14' | 'under14') => void;
+  onBlur: () => void;
+  error?: string;
+}
+
+export default function AgeGroupSelect({ value, onChange, onBlur, error }: AgeGroupSelectProps) {
+  const options = [
+    { value: 'over14' as const, label: '만 14세 이상입니다' },
+    { value: 'under14' as const, label: '만 14세 미만입니다', sub: '보호자 동의가 필요합니다' },
+  ];
+
+  return (
+    <fieldset className="space-y-3">
+      <legend className="text-lg font-semibold text-text-primary mb-4">
+        연령대 선택 <span className="text-error">*</span>
+      </legend>
+      
+      <div className="space-y-3">
+        {options.map((option) => (
+          <label
+            key={option.value}
+            className={`flex items-start gap-3 p-4 border rounded-lg cursor-pointer transition-all ${
+              value === option.value
+                ? 'border-primary bg-primary/5'
+                : 'border-border-light hover:border-primary/50 hover:bg-bg-page'
+            }`}
+          >
+            <input
+              type="radio"
+              name="ageGroup"
+              value={option.value}
+              checked={value === option.value}
+              onChange={(e) => onChange(e.target.value as 'over14' | 'under14')}
+              onBlur={onBlur}
+              className="mt-1 w-4 h-4 text-primary focus:ring-primary"
+            />
+            <div className="flex-1">
+              <span className="text-text-primary font-medium">{option.label}</span>
+              {option.sub && (
+                <p className="text-sm text-text-muted mt-1">{option.sub}</p>
+              )}
+            </div>
+          </label>
+        ))}
+      </div>
+
+      {error && (
+        <p className="text-sm text-error mt-2">{error}</p>
+      )}
+    </fieldset>
+  );
+}

--- a/src/components/Auth/RegisterComplete.tsx
+++ b/src/components/Auth/RegisterComplete.tsx
@@ -1,0 +1,47 @@
+// src/components/Auth/RegisterComplete.tsx
+
+interface RegisterCompleteProps {
+  onLogin: () => void;
+}
+
+export default function RegisterComplete({ onLogin }: RegisterCompleteProps) {
+  return (
+    <div className="text-center py-12">
+      {/* 성공 아이콘 */}
+      <div className="w-24 h-24 mx-auto mb-6 bg-primary/10 rounded-full flex items-center justify-center">
+        <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center">
+          <svg
+            className="w-10 h-10 text-white"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={3}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        </div>
+      </div>
+
+      {/* 완료 메시지 */}
+      <h3 className="text-2xl font-bold text-text-primary mb-3">
+        회원가입이 완료되었습니다!
+      </h3>
+      <p className="text-text-secondary mb-8">
+        Privideo의 모든 기능을 이용하실 수 있습니다.
+      </p>
+
+      {/* 로그인 버튼 */}
+      <button
+        type="button"
+        onClick={onLogin}
+        className="px-10 py-3 bg-primary text-white rounded-lg font-semibold hover:bg-primary-light transition-colors shadow-lg"
+      >
+        로그인하기
+      </button>
+    </div>
+  );
+}

--- a/src/components/Auth/RegisterForm.tsx
+++ b/src/components/Auth/RegisterForm.tsx
@@ -1,0 +1,243 @@
+// src/components/Auth/RegisterForm.tsx
+import { useState } from 'react';
+import { HiUser, HiPhone, HiMail, HiLockClosed, HiEye, HiEyeOff, HiOfficeBuilding } from 'react-icons/hi';
+
+interface RegisterFormProps {
+  values: {
+    name: string;
+    gender: string;
+    age: string;
+    phone: string;
+    email: string;
+    password: string;
+    confirm: string;
+    organizationCode: string;
+  };
+  onChange: (key: string, value: any) => void;
+  onBlur: (key: string) => void;
+  errors: Record<string, string>;
+  touched: Record<string, boolean>;
+  hasError: (key: string) => boolean;
+}
+
+export default function RegisterForm({
+  values,
+  onChange,
+  onBlur,
+  errors,
+  touched,
+  hasError,
+}: RegisterFormProps) {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  return (
+    <div className="space-y-5">
+      {/* 이름 */}
+      <div>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          이름 <span className="text-error">*</span>
+        </label>
+        <div
+          className={`flex items-center border rounded-lg overflow-hidden transition-colors ${
+            hasError('name') ? 'border-error' : 'border-border-light focus-within:border-primary'
+          }`}
+        >
+          <HiUser className="ml-3 text-text-muted text-xl" />
+          <input
+            type="text"
+            className="flex-1 px-3 py-3 text-text-primary placeholder:text-text-muted focus:outline-none"
+            placeholder="이름을 입력해 주세요"
+            value={values.name}
+            onChange={(e) => onChange('name', e.target.value)}
+            onBlur={() => onBlur('name')}
+          />
+        </div>
+        {hasError('name') && <p className="mt-1 text-sm text-error">{errors.name}</p>}
+      </div>
+
+      {/* 성별 (필수) */}
+      <div>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          성별 <span className="text-error">*</span>
+        </label>
+        <div className="flex gap-3">
+          {['male', 'female', 'other'].map((gender) => (
+            <label
+              key={gender}
+              className={`flex-1 flex items-center justify-center gap-2 p-3 border rounded-lg cursor-pointer transition-all ${
+                values.gender === gender
+                  ? 'border-primary bg-primary/5 text-primary'
+                  : 'border-border-light hover:border-primary/50'
+              }`}
+            >
+              <input
+                type="radio"
+                name="gender"
+                value={gender}
+                checked={values.gender === gender}
+                onChange={(e) => onChange('gender', e.target.value)}
+                onBlur={() => onBlur('gender')}
+                className="sr-only"
+              />
+              <span className="font-medium">
+                {gender === 'male' ? '남성' : gender === 'female' ? '여성' : '기타'}
+              </span>
+            </label>
+          ))}
+        </div>
+        {hasError('gender') && <p className="mt-1 text-sm text-error">{errors.gender}</p>}
+      </div>
+
+      {/* 연령대 (필수) */}
+      <div>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          연령대 <span className="text-error">*</span>
+        </label>
+        <select
+          value={values.age}
+          onChange={(e) => onChange('age', e.target.value)}
+          onBlur={() => onBlur('age')}
+          className={`w-full px-4 py-3 border rounded-lg focus:outline-none transition-colors ${
+            hasError('age') ? 'border-error' : 'border-border-light focus:border-primary'
+          }`}
+        >
+          <option value="">연령대를 선택해주세요</option>
+          <option value="10s">10대</option>
+          <option value="20s">20대</option>
+          <option value="30s">30대</option>
+          <option value="40s">40대</option>
+          <option value="50s">50대</option>
+          <option value="60+">60대 이상</option>
+        </select>
+        {hasError('age') && <p className="mt-1 text-sm text-error">{errors.age}</p>}
+      </div>
+
+      {/* 전화번호 */}
+      <div>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          전화번호 <span className="text-error">*</span>
+        </label>
+        <div
+          className={`flex items-center border rounded-lg overflow-hidden transition-colors ${
+            hasError('phone') ? 'border-error' : 'border-border-light focus-within:border-primary'
+          }`}
+        >
+          <HiPhone className="ml-3 text-text-muted text-xl" />
+          <input
+            type="tel"
+            className="flex-1 px-3 py-3 text-text-primary placeholder:text-text-muted focus:outline-none"
+            placeholder="01012345678"
+            value={values.phone}
+            onChange={(e) => onChange('phone', e.target.value)}
+            onBlur={() => onBlur('phone')}
+          />
+        </div>
+        {hasError('phone') && <p className="mt-1 text-sm text-error">{errors.phone}</p>}
+      </div>
+
+      {/* 이메일 */}
+      <div>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          이메일 <span className="text-error">*</span>
+        </label>
+        <div
+          className={`flex items-center border rounded-lg overflow-hidden transition-colors ${
+            hasError('email') ? 'border-error' : 'border-border-light focus-within:border-primary'
+          }`}
+        >
+          <HiMail className="ml-3 text-text-muted text-xl" />
+          <input
+            type="email"
+            className="flex-1 px-3 py-3 text-text-primary placeholder:text-text-muted focus:outline-none"
+            placeholder="you@example.com"
+            value={values.email}
+            onChange={(e) => onChange('email', e.target.value)}
+            onBlur={() => onBlur('email')}
+          />
+        </div>
+        {hasError('email') && <p className="mt-1 text-sm text-error">{errors.email}</p>}
+      </div>
+
+      {/* 비밀번호 */}
+      <div>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          비밀번호 <span className="text-error">*</span>
+        </label>
+        <div
+          className={`flex items-center border rounded-lg overflow-hidden transition-colors ${
+            hasError('password') ? 'border-error' : 'border-border-light focus-within:border-primary'
+          }`}
+        >
+          <HiLockClosed className="ml-3 text-text-muted text-xl" />
+          <input
+            type={showPassword ? 'text' : 'password'}
+            className="flex-1 px-3 py-3 text-text-primary placeholder:text-text-muted focus:outline-none"
+            placeholder="비밀번호 (8자 이상)"
+            value={values.password}
+            onChange={(e) => onChange('password', e.target.value)}
+            onBlur={() => onBlur('password')}
+          />
+          <button
+            type="button"
+            className="px-3 text-text-muted hover:text-primary transition-colors"
+            onClick={() => setShowPassword(!showPassword)}
+          >
+            {showPassword ? <HiEye className="text-xl" /> : <HiEyeOff className="text-xl" />}
+          </button>
+        </div>
+        {hasError('password') && <p className="mt-1 text-sm text-error">{errors.password}</p>}
+      </div>
+
+      {/* 비밀번호 확인 */}
+      <div>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          비밀번호 확인 <span className="text-error">*</span>
+        </label>
+        <div
+          className={`flex items-center border rounded-lg overflow-hidden transition-colors ${
+            hasError('confirm') ? 'border-error' : 'border-border-light focus-within:border-primary'
+          }`}
+        >
+          <HiLockClosed className="ml-3 text-text-muted text-xl" />
+          <input
+            type={showConfirm ? 'text' : 'password'}
+            className="flex-1 px-3 py-3 text-text-primary placeholder:text-text-muted focus:outline-none"
+            placeholder="비밀번호 재입력"
+            value={values.confirm}
+            onChange={(e) => onChange('confirm', e.target.value)}
+            onBlur={() => onBlur('confirm')}
+          />
+          <button
+            type="button"
+            className="px-3 text-text-muted hover:text-primary transition-colors"
+            onClick={() => setShowConfirm(!showConfirm)}
+          >
+            {showConfirm ? <HiEye className="text-xl" /> : <HiEyeOff className="text-xl" />}
+          </button>
+        </div>
+        {hasError('confirm') && <p className="mt-1 text-sm text-error">{errors.confirm}</p>}
+      </div>
+
+      {/* 조직 코드 (선택) */}
+      <div>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          조직 코드 <span className="text-text-muted text-xs">(선택)</span>
+        </label>
+        <div className="flex items-center border border-border-light rounded-lg overflow-hidden focus-within:border-primary transition-colors">
+          <HiOfficeBuilding className="ml-3 text-text-muted text-xl" />
+          <input
+            type="text"
+            className="flex-1 px-3 py-3 text-text-primary placeholder:text-text-muted focus:outline-none"
+            placeholder="조직 코드를 입력해 주세요"
+            value={values.organizationCode}
+            onChange={(e) => onChange('organizationCode', e.target.value)}
+          />
+        </div>
+        <p className="mt-1 text-xs text-text-muted">
+          조직에 소속되어 있다면 조직 코드를 입력해주세요
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/StepIndicator.tsx
+++ b/src/components/Auth/StepIndicator.tsx
@@ -1,0 +1,58 @@
+// src/components/Auth/StepIndicator.tsx
+
+interface StepIndicatorProps {
+  currentStep: number;
+  steps: string[];
+  onStepClick: (step: number) => void;
+}
+
+export default function StepIndicator({ currentStep, steps, onStepClick }: StepIndicatorProps) {
+  return (
+    <div className="flex items-center justify-center mb-8">
+      <div className="flex items-center max-w-2xl">
+        {steps.map((label, index) => {
+          const stepNumber = index + 1;
+          const isDone = stepNumber < currentStep;
+          const isActive = stepNumber === currentStep;
+          const isClickable = stepNumber < currentStep;
+
+          return (
+            <div key={label} className="flex items-center">
+              {/* 단계 원 */}
+              <div
+                onClick={() => isClickable && onStepClick(stepNumber)}
+                className={`flex flex-col items-center ${isClickable ? 'cursor-pointer' : 'cursor-default'}`}
+              >
+                <div
+                  className={`w-12 h-12 rounded-full flex items-center justify-center font-semibold transition-all duration-300 ${
+                    isDone || isActive
+                      ? 'bg-primary text-white'
+                      : 'bg-border-light text-text-muted'
+                  }`}
+                >
+                  {isDone ? '✓' : stepNumber}
+                </div>
+                <span
+                  className={`mt-2 text-sm font-medium transition-colors whitespace-nowrap ${
+                    isActive ? 'text-primary' : 'text-text-muted'
+                  }`}
+                >
+                  {label}
+                </span>
+              </div>
+
+              {/* 연결선 */}
+              {index < steps.length - 1 && (
+                <div
+                  className={`w-24 h-1 mx-3 transition-colors duration-300 ${
+                    stepNumber < currentStep ? 'bg-primary' : 'bg-border-light'
+                  }`}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/TermsAgreement.tsx
+++ b/src/components/Auth/TermsAgreement.tsx
@@ -1,0 +1,92 @@
+// src/components/Auth/TermsAgreement.tsx
+
+interface TermsAgreementProps {
+  agreeAll: boolean;
+  agreeTos: boolean;
+  agreePrivacy: boolean;
+  agreeMarketing: boolean;
+  onChange: (key: string, value: boolean) => void;
+  onBlur: (key: string) => void;
+  errors: {
+    agreeTos?: string;
+    agreePrivacy?: string;
+  };
+}
+
+export default function TermsAgreement({
+  agreeAll,
+  agreeTos,
+  agreePrivacy,
+  agreeMarketing,
+  onChange,
+  onBlur,
+  errors,
+}: TermsAgreementProps) {
+  return (
+    <div className="space-y-4">
+      {/* 전체 동의 */}
+      <label className="flex items-center gap-3 p-4 bg-bg-section rounded-lg cursor-pointer">
+        <input
+          type="checkbox"
+          checked={agreeAll}
+          onChange={(e) => onChange('agreeAll', e.target.checked)}
+          className="w-5 h-5 text-primary focus:ring-primary rounded"
+        />
+        <span className="text-text-primary font-semibold">전체동의</span>
+      </label>
+
+      <div className="space-y-3">
+        {/* 이용약관 */}
+        <div>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={agreeTos}
+              onChange={(e) => onChange('agreeTos', e.target.checked)}
+              onBlur={() => onBlur('agreeTos')}
+              className="w-4 h-4 text-primary focus:ring-primary rounded"
+            />
+            <span className="text-text-primary">
+              이용약관 동의 <span className="text-error">*</span>
+            </span>
+          </label>
+          {errors.agreeTos && (
+            <p className="text-sm text-error mt-1 ml-7">{errors.agreeTos}</p>
+          )}
+        </div>
+
+        {/* 개인정보 수집 */}
+        <div>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={agreePrivacy}
+              onChange={(e) => onChange('agreePrivacy', e.target.checked)}
+              onBlur={() => onBlur('agreePrivacy')}
+              className="w-4 h-4 text-primary focus:ring-primary rounded"
+            />
+            <span className="text-text-primary">
+              개인정보 수집 및 이용 동의 <span className="text-error">*</span>
+            </span>
+          </label>
+          {errors.agreePrivacy && (
+            <p className="text-sm text-error mt-1 ml-7">{errors.agreePrivacy}</p>
+          )}
+        </div>
+
+        {/* 마케팅 수신 (선택) */}
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={agreeMarketing}
+            onChange={(e) => onChange('agreeMarketing', e.target.checked)}
+            className="w-4 h-4 text-primary focus:ring-primary rounded"
+          />
+          <span className="text-text-muted">
+            [선택] 마케팅 수신 동의
+          </span>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -1,0 +1,202 @@
+// src/pages/Auth/Register.tsx
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import StepIndicator from '@/components/Auth/StepIndicator';
+import AgeGroupSelect from '@/components/Auth/AgeGroupSelect';
+import TermsAgreement from '@/components/Auth/TermsAgreement';
+import RegisterForm from '@/components/Auth/RegisterForm';
+import RegisterComplete from '@/components/Auth/RegisterComplete';
+
+const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+const phoneRe = /^[0-9]{10,11}$/;
+
+const steps = ['약관동의', '정보입력', '가입완료'];
+
+export default function Register() {
+  const [step, setStep] = useState(1);
+  const navigate = useNavigate();
+
+  const [values, setValues] = useState({
+    name: '',
+    gender: '',
+    age: '',
+    phone: '',
+    email: '',
+    password: '',
+    confirm: '',
+    organizationCode: '',
+    ageGroup: '' as '' | 'over14' | 'under14',
+    agreeAll: false,
+    agreeTos: false,
+    agreePrivacy: false,
+    agreeMarketing: false,
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  const validate = () => {
+    const e: Record<string, string> = {};
+    
+    if (step === 1) {
+      if (!values.ageGroup) e.ageGroup = '연령대를 선택해 주세요.';
+      if (!values.agreeTos) e.agreeTos = '이용약관 동의가 필요합니다.';
+      if (!values.agreePrivacy) e.agreePrivacy = '개인정보 수집 동의가 필요합니다.';
+    } else if (step === 2) {
+      if (!values.name.trim()) e.name = '이름을 입력해 주세요.';
+      if (!values.phone) e.phone = '전화번호를 입력해 주세요.';
+      else if (!phoneRe.test(values.phone)) e.phone = '전화번호 형식이 올바르지 않아요.';
+      if (!values.email) e.email = '이메일을 입력해 주세요.';
+      else if (!emailRe.test(values.email)) e.email = '이메일 형식이 올바르지 않아요.';
+      if (!values.password) e.password = '비밀번호를 입력해 주세요.';
+      else if (values.password.length < 8) e.password = '비밀번호는 8자 이상이어야 해요.';
+      if (!values.confirm) e.confirm = '비밀번호 확인을 입력해 주세요.';
+      else if (values.confirm !== values.password) e.confirm = '비밀번호가 일치하지 않아요.';
+    }
+    
+    return e;
+  };
+
+  const handleChange = (key: keyof typeof values, value: any) => {
+    const next = { ...values, [key]: value };
+
+    // 전체 동의 로직
+    if (key === 'agreeAll') {
+      next.agreeTos = next.agreePrivacy = next.agreeMarketing = !!value;
+    }
+    
+    // 개별 약관 체크 시 전체 동의 업데이트
+    if (['agreeTos', 'agreePrivacy', 'agreeMarketing'].includes(key)) {
+      next.agreeAll = next.agreeTos && next.agreePrivacy && next.agreeMarketing;
+    }
+
+    setValues(next);
+    if (touched[key]) setErrors(validate());
+  };
+
+  const handleBlur = (key: string) => {
+    setTouched((prev) => ({ ...prev, [key]: true }));
+    setErrors(validate());
+  };
+
+  const nextStep = () => {
+    const errs = validate();
+    setErrors(errs);
+    
+    const touchFields = step === 1
+      ? { ageGroup: true, agreeTos: true, agreePrivacy: true }
+      : { name: true, phone: true, email: true, password: true, confirm: true };
+    
+    setTouched((prev) => ({ ...prev, ...touchFields }));
+    
+    if (Object.keys(errs).length > 0) return;
+    setStep((s) => s + 1);
+  };
+
+  const prevStep = () => {
+    if (step > 1) setStep((s) => s - 1);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs = validate();
+    setErrors(errs);
+    setTouched(Object.keys(values).reduce((acc, k) => ({ ...acc, [k]: true }), {}));
+    
+    if (Object.keys(errs).length > 0) return;
+    
+    // TODO: 백엔드 API 연동
+    console.log('회원가입 제출:', values);
+    setStep(3);
+  };
+
+  const hasError = (k: string) => !!errors[k] && touched[k];
+
+  return (
+    <div className="min-h-screen bg-bg-page flex items-center justify-center p-4">
+      <div className="w-full max-w-2xl bg-bg-card rounded-2xl shadow-base p-8 lg:p-12">
+        {/* 로고 */}
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-primary mb-2">회원가입</h1>
+          <p className="text-text-secondary text-sm">Privideo에 오신 것을 환영합니다</p>
+        </div>
+
+        {/* 단계 표시 */}
+        <StepIndicator currentStep={step} steps={steps} onStepClick={setStep} />
+
+        {/* 폼 */}
+        <form onSubmit={handleSubmit} noValidate className="mt-8">
+          {/* Step 1: 약관 동의 */}
+          {step === 1 && (
+            <>
+              <AgeGroupSelect
+                value={values.ageGroup}
+                onChange={(value) => handleChange('ageGroup', value)}
+                onBlur={() => handleBlur('ageGroup')}
+                error={hasError('ageGroup') ? errors.ageGroup : undefined}
+              />
+
+              <div className="my-6 border-t border-border-light"></div>
+
+              <TermsAgreement
+                agreeAll={values.agreeAll}
+                agreeTos={values.agreeTos}
+                agreePrivacy={values.agreePrivacy}
+                agreeMarketing={values.agreeMarketing}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                errors={{
+                  agreeTos: hasError('agreeTos') ? errors.agreeTos : undefined,
+                  agreePrivacy: hasError('agreePrivacy') ? errors.agreePrivacy : undefined,
+                }}
+              />
+
+              <button
+                type="button"
+                onClick={nextStep}
+                className="w-full mt-6 py-3 bg-primary text-white rounded-lg font-semibold hover:bg-primary-light transition-colors"
+              >
+                다음
+              </button>
+            </>
+          )}
+
+          {/* Step 2: 정보 입력 */}
+          {step === 2 && (
+            <>
+              <RegisterForm
+                values={values}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                errors={errors}
+                touched={touched}
+                hasError={hasError}
+              />
+
+              <div className="flex gap-3 mt-6">
+                <button
+                  type="button"
+                  onClick={prevStep}
+                  className="flex-1 py-3 bg-bg-page text-text-primary rounded-lg font-semibold hover:bg-border-light transition-colors"
+                >
+                  이전
+                </button>
+                <button
+                  type="submit"
+                  className="flex-1 py-3 bg-primary text-white rounded-lg font-semibold hover:bg-primary-light transition-colors"
+                >
+                  가입완료
+                </button>
+              </div>
+            </>
+          )}
+
+          {/* Step 3: 가입 완료 */}
+          {step === 3 && (
+            <RegisterComplete onLogin={() => navigate('/login')} />
+          )}
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -2,11 +2,16 @@ import { createBrowserRouter } from "react-router-dom";
 import Landing from "@/pages/Home/Landing";
 import LoginHome from "@/pages/Auth/LoginHome";
 import LoginSelect from "@/pages/Auth/LoginSelect"; 
+import Register from "@/pages/Auth/Register";
+
 
 export const router = createBrowserRouter([
   {
     path: "/",
     element: <Landing />,
+  },
+  { path: "register", 
+    element: <Register /> 
   },
   {
     path: "/login",


### PR DESCRIPTION
## ✏️ 요약

이슈 번호 : #5 

## ✅ 변경 사항

- 3단계 회원가입 기능을 구현했습니다.

**회원가입 플로우:**
1. **약관동의 단계**
   - 연령대 선택 (만 14세 이상/미만)
   - 전체동의 체크박스
   - 이용약관 동의 (필수)
   - 개인정보 수집 동의 (필수)
   - 마케팅 수신 동의 (선택)

2. **정보입력 단계**
   - 이름 (필수)
   - 성별 (필수) - 남성/여성/기타
   - 연령대 (필수) - 10대~60대 이상
   - 전화번호 (필수)
   - 이메일 (필수)
   - 비밀번호 (필수, 8자 이상)
   - 비밀번호 확인 (필수)
   - 조직 코드 (선택)

3. **가입완료 단계**
   - 성공 메시지
   - 로그인 페이지 이동 버튼

**주요 기능:**
- 단계별 진행 표시 (StepIndicator)
- 이전 단계로 돌아가기
- 실시간 유효성 검사
- 입력 필드별 에러 메시지
- 비밀번호 표시/숨김 토글
- 전체동의 체크박스 (개별 약관과 연동)

**기술 구현:**
- React Hooks (useState)
- React Router (페이지 이동)
- Tailwind CSS (브랜드 컬러)
- TypeScript (타입 안전성)
- 컴포넌트 분리 (재사용성)

### 반영 브랜치

`feat/signup` -> `develop`

## 💡 리뷰 요구사항
- [ ] 3단계 플로우 동작 확인
- [ ] 단계 간 이동 (다음/이전) 확인
- [ ] 유효성 검사 동작 확인
- [ ] 에러 메시지 표시 확인
- [ ] 전체동의 체크박스 로직 확인
- [ ] 비밀번호 표시/숨김 토글 확인
- [ ] 반응형 디자인 확인

## 📸 확인 방법 (선택)
<img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/9934af2f-9552-45dc-9391-e6f39c0a91ca" />
<img width="1455" height="785" alt="image" src="https://github.com/user-attachments/assets/1ea3be7e-4fce-4452-9f1b-e0b22132644d" />
<img width="1465" height="771" alt="image" src="https://github.com/user-attachments/assets/3fe01dfb-bd17-4643-8415-53e84eddac3b" />



<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
